### PR TITLE
Fix format:check command to ignore .gitignore file

### DIFF
--- a/lessons/code-formatting.md
+++ b/lessons/code-formatting.md
@@ -32,7 +32,7 @@ Add the following two commands to your npm scripts:
   "scripts": {
     […]
     "format": "prettier --ignore-path ./.gitignore --write \"./**/*.{html,json,js,ts,css}\"",
-    "format:check": "prettier ./.gitignore --check \"./**/*.{html,json,js,ts,css}\""
+    "format:check": "prettier --ignore-path ./.gitignore --check \"./**/*.{html,json,js,ts,css}\""
   }
 }
 ```


### PR DESCRIPTION
Running the command `npm run format:check` results in the following error: `.gitignore[error] No parser could be inferred for file: .gitignore`

Adding the `--ignore-path` to the command fixes this issue