### PR TITLE
Fix minor typo in Linting lesson 

### DIFF
--- a/lessons/linting.md
+++ b/lessons/linting.md
@@ -24,7 +24,7 @@ Run this:
 npm install -D eslint eslint-plugin-import eslint-config-prettier
 ```
 
-Add a new file to the root of your project called `.eslintrc.json and put this into it:
+Add a new file to the root of your project called `.eslintrc.json` and put this into it:
 
 ```json
 {


### PR DESCRIPTION
Very minor: 
Added missing closing back tick in linting lesson:

<img width="607" alt="Screenshot 2020-05-31 at 19 03 39" src="https://user-images.githubusercontent.com/16784959/83359330-7ce16680-a371-11ea-85ea-50a78b3a12e9.png">

Thank you for an excellent project 🦊 