### PR TITLE
Fix typo in initButtons function

### DIFF
--- a/lessons/interacting-with-the-ui.md
+++ b/lessons/interacting-with-the-ui.md
@@ -31,6 +31,8 @@ export default function initButtons(handleUserAction) {
       toggleHighlighted(selectedIcon, true);
     } else {
       handleUserAction(ICONS[selectedIcon]);
+    }
+  }
   document.querySelector(".buttons").addEventListener("click", buttonClick);
 }
 ```


### PR DESCRIPTION
Typo in one of the code blocks in `Interacting with the UI` lesson: 

Added missing closing curly braces and moved document.queryselector out of else statement